### PR TITLE
Add scroll restoration on route change with ScrollToTop component

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -5,6 +5,7 @@ import { Router as ReactRouter } from "react-router-dom";
 import ApplicationContainer from "components/ApplicationContainer";
 import store, { exposeGlobals, history } from "modules/create-store";
 import { NODE_ENV } from "tools/client-env";
+import ScrollToTop from "components/ScrollToTop";
 
 /** ===========================================================================
  * Pairwise App!
@@ -22,6 +23,7 @@ class Pairwise extends React.Component {
     return (
       <ReduxProvider store={store}>
         <ReactRouter history={history}>
+          <ScrollToTop />
           <ApplicationContainer />
         </ReactRouter>
       </ReduxProvider>

--- a/packages/client/src/components/ScrollToTop.tsx
+++ b/packages/client/src/components/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
When navigating through the challenges with the "Next Challenge" button, I noticed that the user ends up in the Media Area of the next challenge, rather than in the primary workspace. This PR addresses that.

* Implements scroll restoration (i.e. scroll to top) on every route change
* Solution is exactly according to React Router [docs on this subject](https://reacttraining.com/react-router/web/guides/scroll-restoration)