### PR TITLE
Refactor and standardize selectors exports

### DIFF
--- a/packages/client/src/modules/app/epics.ts
+++ b/packages/client/src/modules/app/epics.ts
@@ -3,7 +3,6 @@ import { Observable } from "rxjs";
 import { isActionOf } from "typesafe-actions";
 import { Location } from "history";
 import { combineEpics } from "redux-observable";
-
 import { EpicSignature } from "../root";
 import { Actions } from "../root-actions";
 

--- a/packages/client/src/modules/app/index.ts
+++ b/packages/client/src/modules/app/index.ts
@@ -1,6 +1,6 @@
 import actions, { ActionTypes } from "./actions";
 import epics from "./epics";
-import selector from "./selectors";
+import * as selector from "./selectors";
 import store, { State } from "./store";
 
 const app = {

--- a/packages/client/src/modules/app/selectors.ts
+++ b/packages/client/src/modules/app/selectors.ts
@@ -18,13 +18,3 @@ export const locationSelector = createSelector(
   appSelector,
   app => app.location,
 );
-
-/** ===========================================================================
- * Export
- * ============================================================================
- */
-
-export default {
-  appSelector,
-  locationSelector,
-};

--- a/packages/client/src/modules/auth/epics.ts
+++ b/packages/client/src/modules/auth/epics.ts
@@ -12,7 +12,6 @@ import {
 } from "rxjs/operators";
 import { isActionOf } from "typesafe-actions";
 import { of } from "rxjs";
-
 import {
   setAccessTokenInLocalStorage,
   logoutUserInLocalStorage,

--- a/packages/client/src/modules/auth/index.ts
+++ b/packages/client/src/modules/auth/index.ts
@@ -1,6 +1,6 @@
 import actions, { ActionTypes } from "./actions";
 import epics from "./epics";
-import selector from "./selectors";
+import * as selector from "./selectors";
 import store, { State } from "./store";
 
 const auth = {

--- a/packages/client/src/modules/auth/selectors.ts
+++ b/packages/client/src/modules/auth/selectors.ts
@@ -27,14 +27,3 @@ export const userAuthenticated = createSelector(
     return Boolean(authStateResult.accessToken);
   },
 );
-
-/** ===========================================================================
- * Export
- * ============================================================================
- */
-
-export default {
-  authSelector,
-  userAuthenticated,
-  singleSignOnDialogState,
-};

--- a/packages/client/src/modules/challenges/epics.ts
+++ b/packages/client/src/modules/challenges/epics.ts
@@ -23,7 +23,6 @@ import { Actions } from "../root-actions";
 import { InverseChallengeMapping } from "./types";
 import { SANDBOX_ID } from "tools/constants";
 import { Location } from "history";
-import { getBlobCache, nextPrevChallenges } from "./selectors";
 
 /** ===========================================================================
  * Epics
@@ -247,13 +246,16 @@ const saveCourse: EpicSignature = (action$, _, deps) => {
 const handleFetchCodeBlobForChallengeEpic: EpicSignature = (
   action$,
   state$,
+  deps,
 ) => {
   return action$.pipe(
     filter(isActionOf(Actions.setChallengeId)),
     pluck("payload"),
     pluck("newChallengeId"),
     mergeMap(id => {
-      const { next, prev } = nextPrevChallenges(state$.value);
+      const { next, prev } = deps.selectors.challenges.nextPrevChallenges(
+        state$.value,
+      );
 
       const actions = [Actions.fetchBlobForChallenge(id)];
 
@@ -315,7 +317,7 @@ const handleSaveCodeBlobEpic: EpicSignature = (action$, state$, deps) => {
     pluck("payload"),
     pluck("previousChallengeId"),
     map(challengeId => {
-      const blobs = getBlobCache(state$.value);
+      const blobs = deps.selectors.challenges.getBlobCache(state$.value);
       if (challengeId in blobs) {
         const codeBlob: ICodeBlobDto = {
           challengeId,

--- a/packages/client/src/modules/create-store.ts
+++ b/packages/client/src/modules/create-store.ts
@@ -5,7 +5,13 @@ import { createEpicMiddleware } from "redux-observable";
 
 import * as ENV from "../tools/client-env";
 import api from "./api";
-import { EpicDependencies, Modules, rootEpic, rootReducer } from "./root";
+import {
+  EpicDependencies,
+  Modules,
+  selectors,
+  rootEpic,
+  rootReducer,
+} from "./root";
 import { AppToaster } from "tools/constants";
 import logger from "tools/logger";
 
@@ -23,6 +29,7 @@ const history = createBrowserHistory();
 
 const dependencies: EpicDependencies = {
   api,
+  selectors,
   router: history,
   toaster: AppToaster,
 };

--- a/packages/client/src/modules/purchase/epics.ts
+++ b/packages/client/src/modules/purchase/epics.ts
@@ -2,7 +2,6 @@ import { combineEpics } from "redux-observable";
 import { filter, tap, mergeMap } from "rxjs/operators";
 import { isActionOf } from "typesafe-actions";
 import { of, combineLatest } from "rxjs";
-
 import {
   removeEphemeralPurchaseCourseId,
   getEphemeralPurchaseCourseId,
@@ -11,7 +10,6 @@ import {
 import { EpicSignature } from "../root";
 import { Actions } from "../root-actions";
 import { CourseSkeletonList } from "@pairwise/common";
-import { userProfile } from "modules/user/selectors";
 
 /** ===========================================================================
  * Epics
@@ -73,7 +71,7 @@ const handlePurchaseCourseIntentEpic: EpicSignature = (
     filter(isActionOf(Actions.handlePurchaseCourseIntent)),
     mergeMap(action => {
       const courseId = action.payload.courseId;
-      const user = userProfile(state$.value);
+      const user = deps.selectors.user.userProfile(state$.value);
       if (user) {
         return of(
           Actions.setPurchaseCourseId(courseId),

--- a/packages/client/src/modules/purchase/index.ts
+++ b/packages/client/src/modules/purchase/index.ts
@@ -1,6 +1,6 @@
 import actions, { ActionTypes } from "./actions";
 import epics from "./epics";
-import selector from "./selectors";
+import * as selector from "./selectors";
 import store, { State } from "./store";
 
 const purchase = {

--- a/packages/client/src/modules/purchase/selectors.ts
+++ b/packages/client/src/modules/purchase/selectors.ts
@@ -23,14 +23,3 @@ export const coursePurchaseId = createSelector(
   purchaseState,
   purchase => purchase.purchaseCourseId,
 );
-
-/** ===========================================================================
- * Export
- * ============================================================================
- */
-
-export default {
-  purchaseState,
-  coursePurchaseId,
-  coursePurchaseModalStateSelector,
-};

--- a/packages/client/src/modules/root.ts
+++ b/packages/client/src/modules/root.ts
@@ -82,6 +82,7 @@ export interface EpicDependencies {
   router: History<any>;
   api: typeof API;
   toaster: IToaster;
+  selectors: typeof selectors;
 }
 
 export type EpicSignature = Epic<

--- a/packages/client/src/modules/user/epics.ts
+++ b/packages/client/src/modules/user/epics.ts
@@ -1,7 +1,6 @@
 import { combineEpics } from "redux-observable";
 import { filter, map, mergeMap, pluck } from "rxjs/operators";
 import { isActionOf } from "typesafe-actions";
-
 import API from "modules/api";
 import { EpicSignature } from "../root";
 import { Actions } from "../root-actions";

--- a/packages/client/src/modules/user/index.ts
+++ b/packages/client/src/modules/user/index.ts
@@ -1,6 +1,6 @@
 import actions, { ActionTypes } from "./actions";
 import epics from "./epics";
-import selector from "./selectors";
+import * as selector from "./selectors";
 import store, { State } from "./store";
 
 const user = {

--- a/packages/client/src/modules/user/selectors.ts
+++ b/packages/client/src/modules/user/selectors.ts
@@ -42,19 +42,3 @@ export const userProgress = createSelector(
   userState,
   state => state.user.progress,
 );
-
-/** ===========================================================================
- * Export
- * ============================================================================
- */
-
-export default {
-  editorOptions,
-  loading,
-  userSelector,
-  userProfile,
-  userSettings,
-  userCourses,
-  userPayments,
-  userProgress,
-};


### PR DESCRIPTION
**This PR:**

* Refactor `selectors` setup and remove combined exports so the structure is simpler and more consistent.
* Add `selectors` global to epic dependencies and remove individual selector imports in epics files.