### PR TITLE
Fix heading anchor link inconsistency

### DIFF
--- a/packages/client/global.d.ts
+++ b/packages/client/global.d.ts
@@ -53,3 +53,11 @@ declare module "rich-markdown-editor" {
 
   export default Editor;
 }
+
+declare module "rich-markdown-editor/lib/lib/headingToSlug" {
+  import { Document, Block, Node as SlateNode } from "slate";
+  export default function headingToSlug(
+    document: Document,
+    node: SlateNode,
+  ): string;
+}


### PR DESCRIPTION
* Fixes issue where clicking a TOC item did _not_ scroll the browser to that heading
* Changes scroll behavior to smooth when clicking a TOC heading. Will fallback to default if not supported by browser.