### PR TITLE
Add netlify ignore command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  ignore = "git diff --quiet HEAD~1 HEAD packages/client/"


### PR DESCRIPTION
The idea here is to only rebuild on netlify if the client directory has
seen changes. This is becuase currently the only site we hosted on
netlify is the client site.