### PR TITLE
Add google analytics to our WWW site

### DIFF
--- a/packages/www/gatsby-config.js
+++ b/packages/www/gatsby-config.js
@@ -30,5 +30,16 @@ module.exports = {
         icon: `src/images/favicon2.png`, // This path is relative to the root of the site.
       },
     },
+    {
+      resolve: `gatsby-plugin-google-analytics`,
+      options: {
+        trackingId: 'UA-158972025-2',
+        // Defines where to place the tracking script - `true` in the head and `false` in the body
+        // GA recommends putting this in the head so here we are.
+        head: true,
+        // Aparently required in germany? https://www.gatsbyjs.org/packages/gatsby-plugin-google-analytics/#anonymize
+        anonymize: true,
+      },
+    },
   ],
 };

--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -9,6 +9,7 @@
     "add": "^2.0.6",
     "gatsby": "^2.10.4",
     "gatsby-image": "^2.2.3",
+    "gatsby-plugin-google-analytics": "^2.1.36",
     "gatsby-plugin-manifest": "^2.2.0",
     "gatsby-plugin-material-ui": "^2.1.6",
     "gatsby-plugin-offline": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10956,6 +10956,13 @@ gatsby-page-utils@^0.0.37:
     lodash "^4.17.15"
     micromatch "^3.1.10"
 
+gatsby-plugin-google-analytics@^2.1.36:
+  version "2.1.36"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.1.36.tgz#cbf19c45305ff50b6ab4612e7963ef9184f8b438"
+  integrity sha512-yFp75vJpTvfgqZXYlel4n7G5INykAnRFCrf/n9pn/XdnL7Vx49LzLkjwZ8SJzWIU856mAyxK1MsEJH/JXkOWAg==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+
 gatsby-plugin-manifest@^2.2.0:
   version "2.2.37"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.2.37.tgz#ea385bbd453d8455d3c4715c4f3b1e8c1313a97b"


### PR DESCRIPTION
Previously it was only added to the client app. I.e. app.pairwise.tech