### PR TITLE
Add extra jwt verification logic

### DIFF
--- a/packages/server/src/auth/strategies/jwt.strategy.ts
+++ b/packages/server/src/auth/strategies/jwt.strategy.ts
@@ -1,6 +1,6 @@
 import { ExtractJwt, Strategy } from "passport-jwt";
 import { PassportStrategy } from "@nestjs/passport";
-import { Injectable } from "@nestjs/common";
+import { Injectable, UnauthorizedException } from "@nestjs/common";
 import ENV from "src/tools/server-env";
 import { UserService } from "src/user/user.service";
 
@@ -33,6 +33,16 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
   public async validate(payload: JwtPassportSignPayload) {
     const { uuid } = payload;
+
+    /**
+     * Verify the jwt payload has a uuid. By the way, if the jwt payload
+     * structure every needs to change in the future be aware that this
+     * will impact any existing access tokens out in the wild.
+     */
+    if (!uuid || typeof uuid !== "string") {
+      throw new UnauthorizedException();
+    }
+
     return this.userService.findUserByUuidGetFullProfile(uuid);
   }
 }


### PR DESCRIPTION
**This PR:**

* Add extra verification to ensure the `jwt` payload has a `uuid` property. If it doesn't or it does and it's not a string, the token is invalid.