### PR TITLE
Add an initial loading spinner independent of our app

### DIFF
--- a/packages/client/public/index.html
+++ b/packages/client/public/index.html
@@ -58,6 +58,44 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
+    <div id="pw-initial-loading">
+      <style>
+        @keyframes pw-spin {
+          from {
+            transform: rotateZ(0deg);
+          }
+          to {
+            transform: rotateZ(360deg);
+          }
+        }
+        /* prettier-ignore */
+        body, html { background-color: #1e1e1e; }
+        /* prettier-ignore */
+        .pw-initial-loading { top: 0; left: 0; right: 0; bottom: 0; position: absolute; }
+        /* prettier-ignore */
+        svg.pw-initial-loading { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); animation: pw-spin 1s ease-in-out infinite; }
+      </style>
+      <!-- prettier-ignore -->
+      <svg class="pw-initial-loading" width="78" height="78" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78 78">
+        <g transform="rotate(-90 39 39)">
+          <circle cx="39" cy="39" r="36" fill="none" stroke="#555" stroke-width="6" ></circle>
+          <circle cx="39" cy="39" r="36" fill="none" stroke="#75FBBE" stroke-width="6" stroke-dasharray="226.1946710584651" stroke-dashoffset="113.09733552923255" stroke-linecap="round" class="circle" ></circle>
+        </g>
+      </svg>
+      <script>
+        // Clear this loading spinner once the app has loaded. This is a polling
+        // mechanism. It would be perhaps cleaner to use the actual app init event
+        // but this way everything is located here. The rest of the app doesn't even need
+        // to know that this exists.
+        const interval = setInterval(() => {
+          if (document.querySelector("#root").firstChild) {
+            clearInterval(interval);
+            const el = document.querySelector(".pw-initial-loading");
+            el.parentElement.removeChild(el);
+          }
+        }, 100);
+      </script>
+    </div>
     <% if (process.env.REACT_APP_CODEPRESS === "true") { %>
     <!-- 
       Live Reload was causing issues for us in codepress. Namely it was


### PR DESCRIPTION
Sometimes the app takes a long time to even display the workspace
loading message. This new spinner should appear on the very first load,
before any assets have fetched.

Hopefully this keeps people from thinking the app is broken when it's
just being slow.