### PR TITLE
Add amplitude to pairwise-client

### DIFF
--- a/packages/client/public/index.html
+++ b/packages/client/public/index.html
@@ -1,23 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <% if (process.env.REACT_APP_ENABLE_ANALYTICS === "true") { %>
-    <!-- Google Analytics -->
-    <!-- prettier-ignore -->
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-158972025-1', 'auto');
-      ga('send', 'pageview');
-      </script>
-    <!-- End Google Analytics -->
-    <% } else { %>
-    <!-- [INFO] Analytics scripts omitted for environment: %NODE_ENV% -->
-    <% } %>
-
     <meta charset="utf-8" />
 
     <link rel="icon" type="image/png" href="%PUBLIC_URL%/fav-circle.png" />
@@ -44,6 +27,53 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Pairwise Workspace</title>
+
+    <% if (process.env.REACT_APP_ENABLE_ANALYTICS === "true") { %>
+    <!-- Google Analytics -->
+    <!-- prettier-ignore -->
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+      ga('create', 'UA-158972025-1', 'auto');
+      ga('send', 'pageview');
+      </script>
+    <!-- End Google Analytics -->
+    <!-- Amplitude -->
+    <!-- prettier-ignore -->
+    <script type="text/javascript">
+      (function(e,t){var n=e.amplitude||{_q:[],_iq:{}};var r=t.createElement("script")
+      ;r.type="text/javascript"
+      ;r.integrity="sha384-35+p+zAMRt40eCQKk1/Xowd25miK7ZUBRbn6ikyGdVMfY6iKSyDDJwxFc9z4+HhF"
+      ;r.crossOrigin="anonymous";r.async=true
+      ;r.src="https://cdn.amplitude.com/libs/amplitude-6.0.1-min.gz.js"
+      ;r.onload=function(){if(!e.amplitude.runQueuedFunctions){
+      console.log("[Amplitude] Error: could not load SDK")}}
+      ;var i=t.getElementsByTagName("script")[0];i.parentNode.insertBefore(r,i)
+      ;function s(e,t){e.prototype[t]=function(){
+      this._q.push([t].concat(Array.prototype.slice.call(arguments,0)));return this}}
+      var o=function(){this._q=[];return this}
+      ;var a=["add","append","clearAll","prepend","set","setOnce","unset"]
+      ;for(var u=0;u<a.length;u++){s(o,a[u])}n.Identify=o;var c=function(){this._q=[]
+      ;return this}
+      ;var l=["setProductId","setQuantity","setPrice","setRevenueType","setEventProperties"]
+      ;for(var p=0;p<l.length;p++){s(c,l[p])}n.Revenue=c
+      ;var d=["init","logEvent","logRevenue","setUserId","setUserProperties","setOptOut","setVersionName","setDomain","setDeviceId", "enableTracking", "setGlobalUserProperties","identify","clearUserProperties","setGroup","logRevenueV2","regenerateDeviceId","groupIdentify","onInit","logEventWithTimestamp","logEventWithGroups","setSessionId","resetSessionId"]
+      ;function v(e){function t(t){e[t]=function(){
+      e._q.push([t].concat(Array.prototype.slice.call(arguments,0)))}}
+      for(var n=0;n<d.length;n++){t(d[n])}}v(n);n.getInstance=function(e){
+      e=(!e||e.length===0?"$default_instance":e).toLowerCase()
+      ;if(!n._iq.hasOwnProperty(e)){n._iq[e]={_q:[]};v(n._iq[e])}return n._iq[e]}
+      ;e.amplitude=n})(window,document);
+
+      amplitude.getInstance().init("8d2f9bcdb96618839e23d8ed5eae8979");
+    </script>
+    <!-- End Amplitude -->
+    <% } else { %>
+    <!-- [INFO] Analytics scripts omitted for environment: %NODE_ENV% -->
+    <% } %>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
This adds `app.pairwise.tech` as a data source in amplitude. My hope is that this will allow us to map users from pairwise.tech to the app itself. Giving us better insight into how the site is converting. This is not just for google ads but for the site in general. We want to know how it converts, google ads or no.