### PR TITLE
Fix ios webkit regex

### DIFF
--- a/packages/client/src/test/__snapshots__/test-utils.test.ts.snap
+++ b/packages/client/src/test/__snapshots__/test-utils.test.ts.snap
@@ -12,6 +12,18 @@ Object {
 }
 `;
 
+exports[`test test-utils.ts functions buildPreviewTestResultsFromCode handles single quotes correctly 1`] = `
+Object {
+  "results": Array [
+    Object {
+      "message": "This test case uses single quotes...",
+      "test": "",
+      "testResult": false,
+    },
+  ],
+}
+`;
+
 exports[`test test-utils.ts functions buildPreviewTestResultsFromCode returns an error if testCode does not match regex 1`] = `
 Object {
   "error": [Error: Unable to extract test messages from test code!],

--- a/packages/client/src/test/test-utils.test.ts
+++ b/packages/client/src/test/test-utils.test.ts
@@ -38,4 +38,12 @@ describe("test test-utils.ts functions", () => {
     const result = buildPreviewTestResultsFromCode(testCode);
     expect(result).toMatchSnapshot();
   });
+
+  test("buildPreviewTestResultsFromCode handles single quotes correctly", () => {
+    // tslint:disable-next-line
+    const testCode =
+      "test('This test case uses single quotes...', () => {...})'";
+    const result = buildPreviewTestResultsFromCode(testCode);
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/packages/client/src/tools/test-utils.ts
+++ b/packages/client/src/tools/test-utils.ts
@@ -656,7 +656,7 @@ export const buildPreviewTestResultsFromCode = (
   testCode: string,
 ): { results?: TestCase[]; error?: Error } => {
   try {
-    const pattern = /test\("(.*)",/g;
+    const pattern = /test\(["'](.*)["'],/g;
     const matches = testCode.match(pattern) ?? [];
     const results = matches.map(match => {
       return {


### PR DESCRIPTION
We had a regex that seemed to be throwing errors in safari on ios. Apparently our old regex is not supported in apple products.

I tested in the iOS simulator.